### PR TITLE
fix bug checking for pipeline dependency cycles

### DIFF
--- a/schemas/pipeline.go
+++ b/schemas/pipeline.go
@@ -177,7 +177,7 @@ func (g dependencyGraph) checkForDependencyCycles() error {
 	}
 
 	// Prime the visit stack with the first independent errand and remove it from the list.
-	toVisitStack := independentErrands[0:1]
+	toVisitStack := []*Errand{independentErrands[0]}
 	independentErrands = independentErrands[1:]
 
 	// visitedSet keeps track of all the errands we've already seen so we can ensure we've seen all of them

--- a/schemas/pipeline_test.go
+++ b/schemas/pipeline_test.go
@@ -226,4 +226,34 @@ func TestPipelineValidate(t *testing.T) {
 
 		assert.NoError(t, p.Validate())
 	})
+
+	t.Run("single graph happy path | converging and diverging", func(t *testing.T) {
+		/*
+			A --> B --|        |--> E
+			          |--> C --|
+			      D --|        |--> F --> G
+		*/
+		p := Pipeline{
+			Name: "single graph with cycle",
+			Errands: []*Errand{
+				{Name: "A"},
+				{Name: "B"},
+				{Name: "C"},
+				{Name: "D"},
+				{Name: "E"},
+				{Name: "F"},
+				{Name: "G"},
+			},
+			Dependencies: []*PipelineDependency{
+				{Target: "B", DependsOn: "A"},
+				{Target: "C", DependsOn: "B"},
+				{Target: "C", DependsOn: "D"},
+				{Target: "E", DependsOn: "C"},
+				{Target: "F", DependsOn: "C"},
+				{Target: "G", DependsOn: "F"},
+			},
+		}
+
+		assert.NoError(t, p.Validate())
+	})
 }


### PR DESCRIPTION
Fixes a bug where we'd find a dependency cycle where there was none. `toVisitStack` was just a view into the underlying array backing `independentErrands`, so whenever we changed `toVisitStack`, we were changing `independentErrands` too :dizzy: 