### PR TITLE
Add alerts for failed errands

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,8 @@ steps:
   - name: deps
     path: /go/pkg
 
+
+
 volumes:
 - name: deps
   temp: {}
@@ -81,6 +83,18 @@ steps:
       username:
         from_secret: dockerhub_username
 
+  - name: deploy alerts
+    image: polygonio/drone-kube
+    settings:
+      template: _deploy_/alerts.yml
+      namespace: errands
+      ca:
+        from_secret: KUBE_CA_STAGING
+      server:
+        from_secret: KUBE_SERVER_STAGING
+      token:
+        from_secret: KUBE_TOKEN_STAGING
+
 trigger:
   branch:
     - master
@@ -112,6 +126,18 @@ steps:
         - ${DRONE_TAG}
       username:
         from_secret: dockerhub_username
+
+  - name: deploy alerts
+    image: polygonio/drone-kube
+    settings:
+      template: _deploy_/alerts.yml
+      namespace: errands
+      ca:
+        from_secret: KUBE_CA
+      server:
+        from_secret: KUBE_SERVER
+      token:
+        from_secret: KUBE_TOKEN
 
 trigger:
   event:

--- a/_deploy_/alerts.yml
+++ b/_deploy_/alerts.yml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name:  alerts-errands
+  namespace: {{namespace}}
+spec:
+  groups:
+    - name: errands-server
+      rules:
+        - alert: Errand Failure
+          annotations:
+            message: Errand failed to complete successfully.
+            runbook_url: https://github.com/polygon-io/backend/wiki/%5BRunbook%5D-Errand-Failure
+            dashboard_url: https://grafana.internal.polygon.io/d/vs_XdP9Vz/errands?orgId=1&viewPanel=2
+          expr: |
+            sum by(errand_type) (rate(poly_errands_completed_total{status="failed"}[$__rate_interval]))
+          for: 24h
+          labels:
+            experimental: "true"
+            severity: warning
+            service_group: apps


### PR DESCRIPTION
This is an initial addition for alerts in errands-server package. This may need to be adjuected and made more granular depending on noise and preexisting behaviors that are not as known due to absense of alerts on failers

 ### Changes
- added _deploy_/alerts.yml which includes an alert for failed errands
- additional drone steps

 ### Tests
- none as of yet. changes are marked experimental.